### PR TITLE
if string is not null set variable and not the opposite

### DIFF
--- a/configure
+++ b/configure
@@ -387,9 +387,9 @@ fi
 
 
 if find_library "imagequant" "imagequant" "libimagequant.h" "libimagequant.a" "libimagequant.$SOLIBSUFFIX*"; then
-    if [ -z "$LIBRARY_FOUND_VERSION" ]; then
+    if [ -n "$LIBRARY_FOUND_VERSION" ]; then
         VERSION=$LIBRARY_FOUND_VERSION
-    elif [ -z "$LIBRARY_FOUND_HEADER" ]; then
+    elif [ -n "$LIBRARY_FOUND_HEADER" ]; then
         VERSION=$(grep LIQ_VERSION_STRING "$LIBRARY_FOUND_HEADER" | grep -Eo "2\.[0-9.]+")
     else
         VERSION=unknown


### PR DESCRIPTION
Hi, 
I found this small bug after saw [1] when running configure .
Best regards,
[1]
imagequant: shared (2.11.10)
grep: : No such file or directory