### PR TITLE
Correct Supported Source (now Super Source) link

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,4 +75,4 @@ pngquant is dual-licensed:
 
 * Under **GPL v3** or later with an additional [copyright notice](https://github.com/kornelski/pngquant/blob/master/COPYRIGHT) that must be kept for the older parts of the code.
 
-* Or [a **commercial license**](https://supportedsource.org/projects/pngquant) for use in non-GPL software (e.g. closed-source or App Store distribution). You can [get the license via Supported Source](https://supportedsource.org/projects/pngquant/purchase). Email kornel@pngquant.org if you have any questions.
+* Or [a **commercial license**](https://supportedsource.org/projects/pngquant) for use in non-GPL software (e.g. closed-source or App Store distribution). You can [get the license via Super Source](https://supso.org/projects/pngquant). Email kornel@pngquant.org if you have any questions.


### PR DESCRIPTION
The link to the commercial license wasn't working. Super Source seems to be the successor of Supported Source and **pngquant** project is there. A link to the project was used instead of a direct link to the purchase page though.