### PR TITLE
Use PKG_CONFIG environment variable if set

### DIFF
--- a/configure
+++ b/configure
@@ -159,10 +159,11 @@ find_h() {
 
 find_pkgconfig() {
     local LIBNAME=$1
-    if pkg-config --exists "$LIBNAME" &> /dev/null; then
-        cflags "$(pkg-config --cflags "$LIBNAME")"
-        lflags "$(pkg-config --libs "$LIBNAME")"
-        LIBRARY_FOUND_VERSION=$(pkg-config --modversion "$LIBNAME")
+    PKG_CONFIG=${PKG_CONFIG:-pkg-config}
+    if $PKG_CONFIG --exists "$LIBNAME" &> /dev/null; then
+        cflags "$($PKG_CONFIG --cflags "$LIBNAME")"
+        lflags "$($PKG_CONFIG --libs "$LIBNAME")"
+        LIBRARY_FOUND_VERSION=$($PKG_CONFIG --modversion "$LIBNAME")
         status "$LIBNAME" "shared ($LIBRARY_FOUND_VERSION)"
         return 0
     fi


### PR DESCRIPTION
Using $PKG_CONFIG if available instead of pkg-config is a convention that makes cross compilation possible.