### PR TITLE
Change readme to match cli help on default speed

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Don't write converted files if the conversion isn't worth it.
 
 ### `--speed N`
 
-Speed/quality trade-off from 1 (slowest, highest quality, smallest files) to 11 (fastest, less consistent quality, light comperssion). The default is 3. It's recommended to keep the default, unless you need to generate images in real time (e.g. map tiles). Higher speeds are fine with 256 colors, but don't handle lower number of colors well.
+Speed/quality trade-off from 1 (slowest, highest quality, smallest files) to 11 (fastest, less consistent quality, light comperssion). The default is 4. It's recommended to keep the default, unless you need to generate images in real time (e.g. map tiles). Higher speeds are fine with 256 colors, but don't handle lower number of colors well.
 
 ### `--nofs`
 


### PR DESCRIPTION
Commit d36ef9ad5da7e08564fff9df594f94a5a0bcd8d0 updated the behaviour and CLI help, but didn't update the readme. See #313. 