### PR TITLE
snap: Add snapcraft.yaml file

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,0 +1,34 @@
+name: pngquant
+version: 2.12.0
+summary: pngquant
+description: |
+  Lossy PNG compressor — pngquant command based
+  on libimagequant library https://pngquant.org
+
+confinement: strict
+
+apps:
+  pngquant:
+    command: pngquant
+    plugs:
+    - home
+
+parts:
+  pngquant:
+    source-type: git
+    source: https://github.com/kornelski/pngquant.git
+    source-tag: 2.12.2
+    plugin: autotools
+    configflags:
+      - --with-openmp
+    build-packages:
+      - gcc
+      - make
+      - libpng16-dev
+      - zlib1g-dev
+      - liblcms2-dev
+    stage-packages:
+      - libgomp1
+      - libpng16-16
+      - zlib1g
+      - liblcms2-2


### PR DESCRIPTION
This commit introduces support the bundling/delivering pngquant through
the 'snap' mechanism/store - for more details see https://snapcraft.io.

"A snap is a bundle of your app and its dependencies that works without
modification across Linux.  Snaps are discoverable and installable from
the Snap store, an app store with an audience of millions." [1]

In case the support/snapcraft.yaml file is accepted it can be published
in the Snap Store [2] which is required for people to easily install it.

Assistance for publishing in the snap store is available if required.

Test Procedure
==============

Build/Snap
----------

```
$ lxc launch ubuntu:16.04 snapcrafting  # create 'snapcrafting' container
$ lxc exec snapcrafting -- su - ubuntu  # execute user shell in container

$ sudo snap install snapcraft --classic # install snapcraft tool/commands
$ sudo apt-get update # update for installing build dependencies packages

$ git clone https://github.com/kornelski/pngquant.git
$ cd pngquant

$ # get this snapcraft.yaml file
$ snapcraft
...
Building pngquant
./configure --prefix= --with-openmp

  Compiler: gcc
     Debug: no
       SSE: yes
    OpenMP: yes
imagequant: build static
    libpng: shared (1.6.20)
      zlib: shared ... /usr/lib/x86_64-linux-gnu/libz.so
     lcms2: shared ... /usr/lib/x86_64-linux-gnu/liblcms2.so

make -j4
...
Snapped pngquant_2.12.0_amd64.snap
```

Install/Contents
----------------

```
$ sudo snap install pngquant_2.12.0_amd64.snap --dangerous
  # '--dangerous' is required as this isn't from the store.

$ which pngquant
/snap/bin/pngquant

$ find /snap/pngquant/
...
/snap/pngquant/x1/bin/pngquant
...
/snap/pngquant/x1/lib/x86_64-linux-gnu/libpng16.so.16
/snap/pngquant/x1/lib/x86_64-linux-gnu/libpng16.so.16.20.0
/snap/pngquant/x1/lib/x86_64-linux-gnu/libz.so.1
/snap/pngquant/x1/lib/x86_64-linux-gnu/libz.so.1.2.8
...
/snap/pngquant/x1/usr/lib/x86_64-linux-gnu/libgomp.so.1
/snap/pngquant/x1/usr/lib/x86_64-linux-gnu/libgomp.so.1.0.0
/snap/pngquant/x1/usr/lib/x86_64-linux-gnu/liblcms2.so.2
/snap/pngquant/x1/usr/lib/x86_64-linux-gnu/liblcms2.so.2.0.6
/snap/pngquant/x1/usr/lib/x86_64-linux-gnu/libpng16.so.16
...
```

Testing
-------

```
$ wget -q https://pngquant.org/Ducati_side_shadow.png

$ pngquant Ducati_side_shadow.png

$ ls -lh Ducati_side_shadow*.png
<...> 23K Dec  4 15:53 Ducati_side_shadow-fs8.png
<...> 74K Oct 28 22:56 Ducati_side_shadow.png
```

References:
[1] "Creating a snap" in https://docs.snapcraft.io/creating-a-snap/6799
[2] "Share with your friends" in https://docs.snapcraft.io/c-c-applications/7817

Signed-off-by: Mauricio Faria de Oliveira <mfo@canonical.com>