### PR TITLE
Migrate snap to core18 base

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -5,6 +5,7 @@ description: |
   Lossy PNG compressor — pngquant command based
   on libimagequant library https://pngquant.org
 
+base: core18
 confinement: strict
 
 apps:
@@ -24,7 +25,7 @@ parts:
     build-packages:
       - gcc
       - make
-      - libpng16-dev
+      - libpng-dev
       - zlib1g-dev
       - liblcms2-dev
     stage-packages:


### PR DESCRIPTION
This patch makes the necessary changes to target the snap to core18 base
so that it will benefit from new feature and fixes from Snapcraft.

Note that the snap now requires to build in a Ubuntu 18.04 equivalent
environment.

Signed-off-by: 林博仁(Buo-ren Lin) <Buo.Ren.Lin@gmail.com>