### PR TITLE
Added fuzzer and oss-fuzz build script

### DIFF
--- a/test/fuzzer.c
+++ b/test/fuzzer.c
@@ -1,0 +1,34 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include "rwpng.h"
+#include "libimagequant.h"
+#include "pngquant_opts.h"
+
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+  if (size < 2)
+    return 0;
+
+  char img[256];
+  sprintf(img, "/tmp/libfuzzer.png");
+
+  FILE *fp = fopen(img, "wb");
+  if (!fp)
+    return 0;
+  fwrite(data, size, 1, fp);
+  fclose(fp);
+
+  liq_attr *attr = liq_attr_create();
+  png24_image tmp = {.width=0};
+  liq_image *input_image = NULL;
+  read_image(attr, img, false, &tmp, &input_image, true, true, false);
+  
+  liq_attr_destroy(attr);
+  if(input_image!=NULL){
+    liq_image_destroy(input_image);
+  }
+  rwpng_free_image24(&tmp);
+  unlink(img);
+  return 0; 
+}

--- a/test/oss_fuzz_build.sh
+++ b/test/oss_fuzz_build.sh
@@ -1,0 +1,52 @@
+#!/bin/bash -eu
+
+# Build libpng
+pushd $SRC/pngquant/libpng
+cat scripts/pnglibconf.dfa | \
+  sed -e "s/option WARNING /option WARNING disabled/" \
+> scripts/pnglibconf.dfa.temp
+mv scripts/pnglibconf.dfa.temp scripts/pnglibconf.dfa
+autoreconf -f -i
+./configure \
+  --prefix="$WORK" \
+  --disable-shared \
+  --enable-static \
+  LDFLAGS="-L$WORK/lib" \
+  CPPFLAGS="-I$WORK/include"
+make -j$(nproc)
+make install
+popd
+
+cd $SRC/pngquant
+
+# Remove "static" from read_image
+sed 's/static pngquant_error read_image/pngquant_error read_image/g' -i pngquant.c
+
+# Build pngquant
+make -j$(nproc) V=1
+
+# Rename "main()" to "main2" and compile
+# pngquant.c again. Otherwise libfuzzer will complain
+sed 's/int main(/int main2(/g' -i pngquant.c
+$CC $CFLAGS  -c pngquant.c -o pngquant.o  -I. -O3 \
+	-DNDEBUG -DUSE_SSE=1 -msse -mfpmath=sse \
+	-Wno-unknown-pragmas -I./lib -I./libpng \
+	-I/usr/include
+
+# Collect all .o files into fuzz_lib.a
+find . -name "*.o" -exec ar rcs fuzz_lib.a {} \;
+
+# Build the fuzzer(s)
+$CC $CFLAGS -c $SRC/fuzzer.c -o fuzzer.o -I. \
+	-O3 -DNDEBUG -DUSE_SSE=1 -msse -mfpmath=sse \
+	-Wno-unknown-pragmas -I./lib -I./libpng \
+	-I/usr/include
+
+$CC $CFLAGS fuzzer.o -I. -O3 -DNDEBUG -DUSE_SSE=1 \
+	-msse -mfpmath=sse -Wno-unknown-pragmas \
+	./lib/libimagequant.a ./libpng/.libs/libpng16.a \
+	-L/usr/lib/x86_64-linux-gnu -lz -lm $LIB_FUZZING_ENGINE \
+	fuzz_lib.a -o $OUT/fuzzer
+
+# Create seed corpus
+zip $OUT/fuzzer_seed_corpus.zip $SRC/pngquant/test/img/test.png


### PR DESCRIPTION
I have been working on setting up continuous fuzzing of pngquant by way of Libfuzzer and OSS-fuzz.

I have written a simple fuzzer and set up a draft integration of pngquant at OSS-fuzz: https://github.com/google/oss-fuzz/pull/5078

OSS-fuzz is a free service by Google for open source projects, and upon integration all added fuzzers will be run through regular scheduled jobs and maintainers will be notified if any bugs are found.
Notifications happen through email and include link to detailed bug reports containing a stack trace and reproducible test case.

In the draft integration at OSS-fuzz you can see that all tests complete successfully. In this PR I am moving over the fuzzer and the build script to make it easier to add more fuzzers or make modifications to the existing one.

To complete the integration, a maintainers email address is needed in the `project.yaml` on the OSS-fuzz side.