### PR TITLE
fix: avoid unchecked nullptr deref on invalid lcms transform

### DIFF
--- a/rust/ffi.rs
+++ b/rust/ffi.rs
@@ -31,6 +31,7 @@ pub enum pngquant_error {
     LIBPNG_FATAL_ERROR = 25,
     WRONG_INPUT_COLOR_TYPE = 26,
     LIBPNG_INIT_ERROR = 35,
+    LCMS_FATAL_ERROR = 45,
     TOO_LARGE_FILE = 98,
     TOO_LOW_QUALITY = 99,
 }

--- a/rwpng.c
+++ b/rwpng.c
@@ -376,6 +376,12 @@ static pngquant_error rwpng_read_image24_libpng(FILE *infile, png24_image *mainp
                                                       hOutProfile, TYPE_RGBA_8,
                                                       INTENT_PERCEPTUAL,
                                                       omp_get_max_threads() > 1 ? cmsFLAGS_NOCACHE : 0);
+        if(!hTransform) {
+            png_destroy_read_struct(&png_ptr, &info_ptr, NULL);
+            cmsCloseProfile(hOutProfile);
+            cmsCloseProfile(hInProfile);
+            return LCMS_FATAL_ERROR;
+        }
 
         #pragma omp parallel for \
             if (mainprog_ptr->height*mainprog_ptr->width > 8000) \

--- a/rwpng.h
+++ b/rwpng.h
@@ -32,6 +32,7 @@ typedef enum {
     LIBPNG_FATAL_ERROR = 25,
     WRONG_INPUT_COLOR_TYPE = 26,
     LIBPNG_INIT_ERROR = 35,
+    LCMS_FATAL_ERROR = 45,
     TOO_LARGE_FILE = 98,
     TOO_LOW_QUALITY = 99,
 } pngquant_error;


### PR DESCRIPTION
On invalid data the requested transform from lcms may return nun
successfully. Hence we need to check the return value and early
the function to avoid a segfault.
To distinguish the concrete error, a new error code (45) has been
introduced.

Signed-off-by: Levente Polyak <levente@leventepolyak.net>